### PR TITLE
Fix silent build failure on Linux

### DIFF
--- a/build-log-server.sh
+++ b/build-log-server.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 
-SCRIPT=$(readlink -f ${BASH_SOURCE[0]})
-SCRIPTPATH=`dirname "$SCRIPT"`
-MYDIRBLOCK=$SCRIPTPATH
-CURRWORKINGDIR=`pwd`
+SCRIPTDIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORKINGDIR="`pwd`"
 
 # Ensure environment is set up
 if [ -z "$EPICS_ROOT" ]; then
-    . $MYDIRBLOCK/../../../config_env_base.sh
+    . "$SCRIPTDIR/../../../config_env_base.sh"
 fi
 
-cd "$MYDIRBLOCK/LogServer"
+cd "$SCRIPTDIR/LogServer"
 
-mvn --settings="$MYDIRBLOCK/mvn_user_settings.xml" clean verify
+mvn --settings="$SCRIPTDIR/mvn_user_settings.xml" clean verify
 builderr=$?
 
 # return to previous working directory
-cd "$CURRWORKINGDIR"
+cd "$WORKINGDIR"
 
-if [ $builderr != 0 ]; then
+if [ $builderr -ne 0 ]; then
     exit $builderr
 fi
 

--- a/clean-log-server.sh
+++ b/clean-log-server.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 
-SCRIPT=$(readlink -f ${BASH_SOURCE[0]})
-SCRIPTPATH=`dirname "$SCRIPT"`
-MYDIRBLOCK=$SCRIPTPATH
-CURRWORKINGDIR=`pwd`
+SCRIPTDIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORKINGDIR="`pwd`"
 
 # Ensure environment is set up
 if [ -z "$EPICS_ROOT" ]; then
-    . $MYDIRBLOCK/../../../config_env_base.sh
+    . "$SCRIPTDIR/../../../config_env_base.sh"
 fi
 
-cd "$MYDIRBLOCK/LogServer"
+cd "$SCRIPTDIR/LogServer"
 
-mvn --settings="$MYDIRBLOCK/mvn_user_settings.xml" clean
+mvn --settings="$SCRIPTDIR/mvn_user_settings.xml" clean
 builderr=$?
 
 # return to previous working directory
-cd "$CURRWORKINGDIR"
+cd "$WORKINGDIR"
 
-if [ $builderr != 0 ]; then
+if [ $builderr -ne 0 ]; then
     exit $builderr
 fi
 

--- a/verify-log-server.sh
+++ b/verify-log-server.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 
-SCRIPT=$(readlink -f ${BASH_SOURCE[0]})
-SCRIPTPATH=`dirname "$SCRIPT"`
-MYDIRBLOCK=$SCRIPTPATH
-CURRWORKINGDIR=`pwd`
+SCRIPTDIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORKINGDIR="`pwd`"
 
 # Ensure environment is set up
 if [ -z "$EPICS_ROOT" ]; then
-    . $MYDIRBLOCK/../../../config_env_base.sh
+    . "$SCRIPTDIR/../../../config_env_base.sh"
 fi
 
-cd "$MYDIRBLOCK/LogServer"
+cd "$SCRIPTDIR/LogServer"
 
-mvn --settings="$MYDIRBLOCK/mvn_user_settings.xml" verify
+mvn --settings="$SCRIPTDIR/mvn_user_settings.xml" verify
 builderr=$?
 
 # return to previous working directory
-cd "$CURRWORKINGDIR"
+cd "$WORKINGDIR"
 
-if [ $builderr != 0 ]; then
+if [ $builderr -ne 0 ]; then
     exit $builderr
 fi
 


### PR DESCRIPTION
The build was failing on Linux without being picked up as a failure by `make`.

The failure happened because the method used to detect the location of the script was returning a relative path instead of an absolute one. This resulted in `mvn_user_settings.xml` not being found after a directory change. A different method is now used to get an absolute path.

I thought the reason `make` wasn't picking up the failure was because the check against `$builderr` was using the wrong type of comparison (string rather than integer). But it doesn't seem like that makes a difference here. I kept the change since an integer comparison is technically more correct here.

Will need to investigate why `make` didn't report the failure even though the script was returning status 1.