### PR TITLE
Use cd /d to avoid linked directory issues

### DIFF
--- a/build-log-server.bat
+++ b/build-log-server.bat
@@ -2,7 +2,7 @@
 set CURRWORKINGDIR=%cd%
 set MYDIRBLOCK=%~dp0
 
-cd %MYDIRBLOCK%\LogServer
+cd /d %MYDIRBLOCK%\LogServer
 
 REM need to call config env to ensure a java 8 environment.
 call %MYDIRBLOCK%\..\..\..\config_env.bat
@@ -10,6 +10,6 @@ mvn --settings=%MYDIRBLOCK%mvn_user_settings.xml clean verify
 set builderr=%errorlevel% 
 
 REM return to previous working directory
-cd %CURRWORKINGDIR%
+cd /d %CURRWORKINGDIR%
 
 if %builderr% neq 0 exit /b %builderr% 

--- a/clean-log-server.bat
+++ b/clean-log-server.bat
@@ -2,12 +2,12 @@
 set CURRWORKINGDIR=%cd%
 set MYDIRBLOCK=%~dp0
 
-cd %MYDIRBLOCK%\LogServer
+cd /d %MYDIRBLOCK%\LogServer
 
 mvn --settings=%MYDIRBLOCK%mvn_user_settings.xml clean
 set builderr=%errorlevel% 
 
 REM return to previous working directory
-cd %CURRWORKINGDIR%
+cd /d %CURRWORKINGDIR%
 
 if %builderr% neq 0 exit /b %builderr% 

--- a/start-ioc-demo.bat
+++ b/start-ioc-demo.bat
@@ -1,6 +1,6 @@
 @echo off
 set MYDIRBLOCK=%~dp0
 
-cd %MYDIRBLOCK%
+cd /d %MYDIRBLOCK%
 
 python %MYDIRBLOCK%dev-tools\ioc_message_simulator.py

--- a/start-jms-demo-client.bat
+++ b/start-jms-demo-client.bat
@@ -1,6 +1,6 @@
 @echo off
 set MYDIRBLOCK=%~dp0
 
-cd %MYDIRBLOCK%
+cd /d %MYDIRBLOCK%
 
 python %MYDIRBLOCK%dev-tools\jms_client.py

--- a/start-log-server.bat
+++ b/start-log-server.bat
@@ -7,9 +7,9 @@ call %LOGDIRBLOCK%..\..\..\config_env_base.bat
 
 %HIDEWINDOW% h
 
-cd %LOGDIRBLOCK%LogServer\target\
+cd /d %LOGDIRBLOCK%LogServer\target\
 
 java -Xms32m -Xmx64m -jar IocLogServer-1.0-SNAPSHOT.jar
 
 REM return to previous working directory
-cd %CURRWORKINGDIR%
+cd /d %CURRWORKINGDIR%

--- a/verify-log-server.bat
+++ b/verify-log-server.bat
@@ -2,12 +2,12 @@
 set CURRWORKINGDIR=%cd%
 set MYDIRBLOCK=%~dp0
 
-cd %MYDIRBLOCK%\LogServer
+cd /d %MYDIRBLOCK%\LogServer
 
 mvn --settings=%MYDIRBLOCK%mvn_user_settings.xml verify
 set builderr=%errorlevel% 
 
 REM return to previous working directory
-cd %CURRWORKINGDIR%
+cd /d %CURRWORKINGDIR%
 
 if %builderr% neq 0 exit /b %builderr% 


### PR DESCRIPTION
If `c:\instrument` is linked to a different drive, issues can occur using plain `cd` 