### PR TITLE
Fixes the delimiter issue with config_mysql.bat

### DIFF
--- a/truncate_event.sql
+++ b/truncate_event.sql
@@ -10,9 +10,9 @@
  * Author: Ian Gillingham, July 2024
  */
 
-DELIMITER //
 
-DROP EVENT IF EXISTS log_truncation_event//
+DROP EVENT IF EXISTS log_truncation_event;
+DELIMITER //
 
 CREATE EVENT IF NOT EXISTS log_truncation_event
 	ON SCHEDULE


### PR DESCRIPTION
This fixes the [delimiter issue](https://github.com/ISISComputingGroup/IBEX/issues/8561)

To test:

- [ ] run EPICS\SystemSetup\config_mysql.bat, it should run successfully, not reporting the error
- [ ] After the script has run, check all tables in EPICS\ISIS\IocLogServer\master\log_mysql_schema.txt are successfully created